### PR TITLE
Fix incorrect reading of Content-Disposition

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1114,6 +1114,7 @@ ssize_t parse_content_disposition(char *dest, size_t destlen,
     }
   }
   switch(state) {
+  case CD_BEFORE_DISPOSITION_PARM_NAME:
   case CD_BEFORE_DISPOSITION_TYPE:
   case CD_AFTER_DISPOSITION_TYPE:
   case CD_DISPOSITION_TYPE:


### PR DESCRIPTION
Some servers adds an extra ";" at the end of the Content-Disposition header, which caused aria2 unable to set the filename correctly.

Technically, it should be state 7 at the end of reading the header, but when there is the extra character it ends at state 3 with the filename already read correctly.

Adding that state to the final checklist would fix it. However there may be other situations which may cause problems, but I haven't tested.
